### PR TITLE
Phase 0: Safety-net smoke tests before modernization

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "es6": true,
     "browser": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "parser": "@typescript-eslint/parser",
   "plugins": ["react", "react-hooks", "prettier", "@typescript-eslint"],

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # testing
 /coverage
 
+# tsc incremental build cache
+tsconfig.tsbuildinfo
+
 # production
 /build
 

--- a/MODERNIZATION_PLAN.md
+++ b/MODERNIZATION_PLAN.md
@@ -1,0 +1,222 @@
+# Contact-Book 2026 Modernization Plan
+
+## Context
+
+The project is a Create React App (react-scripts 4.0.0-next) SPA last touched with 2019–2020-era
+dependencies: React 16, react-router-dom 5, Redux 4 with hand-written action-type constants,
+redux-form 8 (unmaintained since 2020), Firebase 7 (deprecated namespaced/compat API), node-sass
+(deprecated, unmaintained), and TypeScript 4.0. CRA itself was archived by Meta in Feb 2025 and no
+longer receives updates. There are currently **zero tests** in the repo despite
+`@testing-library/*` being listed as dependencies.
+
+The goal is to bring every layer up to a 2026-current baseline. Per the project owner's own
+stack/learning goals (Next.js is the primary framework and a stated learning focus), the migration
+target is **Next.js (App Router)** rather than a same-shape Vite swap — this is a larger rewrite
+than a pure version bump, but it's an intentional, justified one, not a premature abstraction.
+Deployment stays on GitHub Pages via Next's static export, so the app's actual runtime behavior
+(all client-side: Firebase auth/Firestore, Redux, forms) doesn't change — only how it's built and
+routed.
+
+Decisions locked in:
+- **Build tool:** Next.js, App Router
+- **Deployment:** static export (`output: 'export'`), keep GitHub Pages
+- **State management:** upgrade Redux/react-redux and adopt `@reduxjs/toolkit` (RTK), replacing
+  the hand-rolled action-type constants and plain reducers/thunks
+- **Forms:** redux-form is unmaintained with no newer major — replace with `react-hook-form`
+- **Firebase:** move from v7 namespaced/compat API to the modular v9+ SDK
+- **Styling:** node-sass + CSS Modules (9 `.scss`/`.module.scss` files) → **Tailwind CSS**; the
+  color/spacing tokens in `styles/variables.scss` become Tailwind theme config, and each
+  component's `.module.scss` classes are converted to utility classes inline
+- **Icons:** `material-icons-react` is an abandoned 2019 package — swap to a maintained
+  alternative (`react-icons`), used in only 3 files
+
+The Firebase Auth migration is a **high-risk** change (touches auth) and gets extra scrutiny: a
+pre-migration safety net of smoke tests, and manual validation of the real login/register flow
+post-migration — not just green typecheck/lint.
+
+This plan is scoped as a **modernization**, not a feature change: no new product behavior, no
+acceptance criteria beyond "the app does exactly what it does today, on current dependencies."
+
+---
+
+## Process & git workflow
+
+- **One phase = one branch = one commit = one MR, then stop.** For each phase below:
+  1. Branch off `feature/modernize-2026`: `feature/modernize-2026-phase-N-<short-name>` (e.g.
+     `feature/modernize-2026-phase-2-firebase-modular`).
+  2. Implement only that phase's scope.
+  3. Commit (single focused commit, or a few if the phase naturally splits — but no
+     phase-straddling commits).
+  4. Open a PR/MR from the phase branch **into `feature/modernize-2026`** (not into `master`).
+  5. **Stop and wait for explicit approval of that PR before starting the next phase's branch.**
+     No phase N+1 branch gets created until phase N's PR is reviewed and approved.
+- This means the 10 phases (0–9) become 10 sequential PRs, each independently revertable, each
+  gated on review before proceeding.
+
+---
+
+## Current → Target versions
+
+| Package | Current | Target (2026) | Why |
+|---|---|---|---|
+| react-scripts | ^4.0.0-next.98 | *removed* | replaced by `next` |
+| react, react-dom | ^16.13.1 | ^19.x | required by Next 15+ |
+| next | — | ^15.x (latest stable) | new build framework |
+| react-router-dom | ^5.2.0 | *removed* | replaced by Next App Router file-based routing |
+| redux | ^4.0.5 | ^5.x | current major |
+| react-redux | ^7.2.1 | ^9.x | current major, React 19-compatible |
+| @reduxjs/toolkit | — | ^2.x | new — replaces hand-written action types/reducers |
+| redux-thunk | ^2.3.0 | *removed* | bundled inside RTK's default middleware |
+| reselect | ^4.0.0 | *removed* | use RTK's re-exported `createSelector` |
+| redux-form | ^8.3.6 | *removed* | unmaintained since 2020 |
+| react-hook-form | — | ^7.x | new — replaces redux-form |
+| firebase | ^7.21.1 | ^12.x (or latest v12+) | v7 compat API deprecated; move to modular SDK |
+| node-sass | ^4.14.1 | *removed* | unmaintained, breaks on modern Node |
+| (7 `.module.scss` + 2 global `.scss` files) | — | *removed* | replaced by Tailwind utility classes |
+| tailwindcss | — | ^4.x (or latest) | new — replaces Sass/CSS Modules styling |
+| postcss, autoprefixer | — | latest | Tailwind's build dependencies |
+| react-select | ^3.1.0 | ^5.x | current major |
+| material-icons-react | ^1.0.4 | *removed* | abandoned; replace with `react-icons` |
+| typescript | ^4.0.3 | ^5.x | current major |
+| eslint-config-react-app | ^5.2.1 | *removed* | CRA-specific |
+| (new) eslint-config-next | — | latest | official Next.js lint config |
+| eslint / typescript-eslint | ^4.x | ^9.x / ^8.x | flat config |
+| prettier | 2.1.2 | ^3.x | current major |
+| @testing-library/react, jest-dom, user-event | 2019–2020 versions | latest (16.x / 6.x / 14.x) | current + actually used going forward |
+| gh-pages | ^3.1.0 | ^6.x | routine bump |
+| normalize.css | ^8.0.1 | latest 8.x | routine bump |
+| @types/* (node, react, react-dom, react-redux) | old | matched to new majors | routine |
+| @types/react-router, @types/react-router-dom, @types/redux-form | present | *removed* | dependencies removed |
+
+Treat the exact patch/minor numbers above as directional — resolve actual `latest` at
+implementation time (`npm view <pkg> version`).
+
+---
+
+## Phased implementation order
+
+Phases run in this order, each as its own branch/commit/PR per the *Process & git workflow* section
+above — later phases depend on earlier ones having already merged into `feature/modernize-2026`:
+
+**Phase 0 — Safety net before touching anything**
+Add minimal smoke tests against the *current* CRA app for the flows that matter most: register,
+login, add/edit/delete a contact, toggle status, filter by email/status. This is the only way to
+verify "no behavior changed" once Next.js + Firebase modular + RHF migrations land. Use the
+existing (currently-unused) `@testing-library/react` setup.
+
+**Phase 1 — Next.js scaffold + tooling**
+Set up `next.config` (`output: 'export'`, `basePath`/`assetPrefix: '/Contact-book'` to match the
+current GitHub Pages path, `images: { unoptimized: true }` since export mode has no image server).
+Bring TypeScript to 5.x with Next's recommended `tsconfig` (`moduleResolution: "bundler"`, JSX
+`preserve`). Install and initialize Tailwind CSS (`tailwindcss`, `postcss`, `autoprefixer`), wire
+it into `app/globals.css` and `tailwind.config`, and port the tokens in `styles/variables.scss`
+(colors, etc.) into the Tailwind theme (`theme.extend.colors`) so the rest of the migration has a
+named palette to use instead of hardcoded utility values. Set up ESLint 9 flat config with
+`eslint-config-next` + Prettier 3. Migrate `public/` assets. Update `package.json` scripts to
+`next dev`/`next build` and point the existing `deploy`/`predeploy` (`gh-pages`) scripts at Next's
+`out/` directory instead of CRA's `build/`.
+
+**Phase 2 — Firebase modular SDK (high-risk: auth)**
+Rewrite `src/store/firebase.js` from `firebase/app` compat imports to modular
+`initializeApp`/`getAuth`/`getFirestore`. Move the hardcoded config into `NEXT_PUBLIC_FIREBASE_*`
+env vars (`.env.local`, add `.env.example`, keep `.env.local` gitignored). Update the Firestore
+calls in `store/actions/Contacts/actions.ts` (collection/doc/get/add/update patterns) and the Auth
+calls in `store/actions/Users/actions.ts` to the modular functional API
+(`signInWithEmailAndPassword`, `createUserWithEmailAndPassword`, etc.). Re-run Phase 0's smoke
+tests against this change specifically; do a manual login/register check before moving on.
+
+**Phase 3 — Routing**
+Replace `routes.tsx` (`Switch`/`Route`/`component=`) with Next App Router files: `app/layout.tsx`
+(root layout hosting the Redux `Provider` + `CurrentUserProvider`, marked `'use client'`),
+`app/page.tsx` (StartPage), and route segments for Authentication and the logged-in Homepage tree.
+Replace `useHistory()` (`pages/Homepage/isLoggedUser/index.tsx`) with `useRouter()` from
+`next/navigation`, and `<Redirect>` (`pages/Authentication/index.tsx`) with `router.replace()`/
+`redirect()`.
+
+**Phase 4 — State management: Redux → RTK**
+Bump `redux`/`react-redux`, add `@reduxjs/toolkit`. Convert `store/reducers/{contacts,user}.ts` +
+`store/actions/{Contacts,Users}/actions.ts` into `createSlice` + `createAsyncThunk`. Replace
+`store/state/index.ts`'s `createStore(reducer, applyMiddleware(thunk))` with `configureStore`.
+Delete `store/constants.js` (RTK generates action types). Re-source `selectors/` from
+`@reduxjs/toolkit`'s `createSelector` instead of `reselect`, then remove `reselect` and
+`redux-thunk` as direct deps.
+
+**Phase 5 — Forms: redux-form → react-hook-form**
+Rewrite `ContactForm/index.tsx` and `AuthForm/index.tsx` off `reduxForm`/`<Field>` onto RHF's
+`useForm`/`register`. Convert `Input/index.tsx` from consuming `WrappedFieldProps`
+(`input`/`meta.{touched,error,warning}`) to RHF's `register` return + `formState.errors` — it's
+already presentational, so this is a props-shape change, not a rewrite. Reuse the existing
+framework-agnostic `validate()` in `utils/index.tsx` as a manual validation resolver. Remove the
+`form` key from `combineReducers` (Phase 4 will have already replaced `combineReducers` with RTK's
+reducer map, so this just means not including it there). Remove `redux-form` and
+`@types/redux-form`.
+
+**Phase 6 — Styling: Sass/CSS Modules → Tailwind CSS**
+Convert the two global stylesheets and 7 `.module.scss` files (`components/{Footer,Loader,Topbar}`,
+`pages/{Authentication,StartPage,Homepage/isLoggedUser,Homepage/isLoggedUser/contactItem}`) one
+component at a time: replace each `import styles from './index.module.scss'` +
+`className={styles.x}` usage with inline Tailwind utility classes, using the Phase 1 theme tokens
+for colors instead of arbitrary values. Delete the `.scss`/`.module.scss` files and `node-sass`/
+`sass` deps once nothing imports them. Visually diff each converted component against the current
+build before moving to the next (this phase is pure presentation — no behavior should change, but
+it's the phase most likely to introduce visual regressions since it touches every component).
+
+**Phase 7 — Remaining dependency bumps**
+`react-select` → v5 (verify `onChange`/styling API in `selectContact/index.tsx`, one usage site).
+`material-icons-react` → `react-icons` in the 3 usage sites (`Topbar`, `contactItem`, and the
+`react-app-env.d.ts` type reference). `normalize.css`, `@types/*` bumps. Remove
+`@types/react-router`, `@types/react-router-dom`.
+
+**Phase 8 — Testing modernization**
+Bump `@testing-library/*` to current majors. Set up a test runner compatible with Next.js (Jest via
+`next/jest`, the officially documented path — avoids introducing a second new tool alongside the
+Next.js migration itself). Port Phase 0's baseline tests into the new structure, plus targeted
+tests for the Phase 2 (Firebase) and Phase 5 (forms) migrations specifically, since those are the
+two behavior-preserving rewrites with the most surface for regressions.
+
+**Phase 9 — Cleanup & deploy verification**
+Remove leftover CRA artifacts (`react-app-env.d.ts` if no longer needed, any CRA-only tsconfig
+options). Update `README.md`'s tech list. Bump `gh-pages`. Run `next build` (static export) and
+verify the `out/` output serves correctly under the `/Contact-book/` basePath. Manually walk every
+user flow (register, login, add/edit/delete/filter/toggle-status contact, logout) against the real
+static export build — typecheck/lint/tests verify correctness, not feature correctness, so this
+manual pass is required before calling the migration done.
+
+---
+
+## Risks
+
+- **Auth behavior drift** (Phase 2): modular Firebase Auth's error-handling/session-persistence
+  defaults differ subtly from the v7 compat API — covered by Phase 0 tests + manual validation.
+- **App Router client/server boundary**: since virtually everything here is Firebase-client-driven
+  and Redux-driven, most components will need `'use client'`. There's no server-rendering upside
+  to chase here — don't try to convert data-fetching to Server Components/Server Actions, that
+  would be scope creep against "modernize versions," not a requirement of this plan.
+- **GitHub Pages basePath**: static export under a non-root path is easy to get subtly wrong
+  (asset 404s). Verify with an actual deployed/served `out/` build, not just `next build` succeeding.
+- **RTK + react-hook-form landing in the same area** (`ContactForm` dispatches `reset('contactForm')`
+  today, which is redux-form-specific): confirm the Phase 4/5 ordering above — RTK lands first so
+  Phase 5 has a stable action layer to call into, not the reverse.
+
+## Verification
+
+- `next build` succeeds with no type errors (`tsc --noEmit` clean) after each phase.
+- ESLint clean under the new flat config.
+- Phase 0 smoke tests (and their Phase 8 successors) pass after every phase that could affect them.
+- Manual walkthrough of the full user flow against the real static export build (Phase 9), not just
+  `next dev`.
+- No remaining references to `react-scripts`, `react-router-dom`, `redux-form`, `node-sass`,
+  `material-icons-react`, or the Firebase compat API anywhere in `src/` (`grep -r` clean).
+
+## Progress log
+
+- [x] Phase 0 — Safety net tests
+- [ ] Phase 1 — Next.js scaffold + tooling
+- [ ] Phase 2 — Firebase modular SDK
+- [ ] Phase 3 — Routing
+- [ ] Phase 4 — State management: Redux → RTK
+- [ ] Phase 5 — Forms: redux-form → react-hook-form
+- [ ] Phase 6 — Styling: Sass/CSS Modules → Tailwind CSS
+- [ ] Phase 7 — Remaining dependency bumps
+- [ ] Phase 8 — Testing modernization
+- [ ] Phase 9 — Cleanup & deploy verification

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "@types/jest": "^26.0.24",
     "@types/node": "^14.10.3",
     "@types/react-dom": "^16.9.8",
     "@types/react-redux": "^7.1.9",

--- a/src/pages/Authentication/index.test.tsx
+++ b/src/pages/Authentication/index.test.tsx
@@ -1,0 +1,107 @@
+jest.mock('store/firebase');
+
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { fireEvent, wait } from '@testing-library/react';
+import { renderWithStore, createTestStore, fakeFirebaseUser } from 'testUtils';
+import Authentication from './index';
+import {
+  mockSignInWithEmailAndPassword,
+  mockCreateUserWithEmailAndPassword,
+  resetFirebaseMock,
+} from 'store/firebaseTestMocks';
+
+beforeEach(() => {
+  resetFirebaseMock();
+});
+
+const renderAuthPage = (
+  path: '/login' | '/register',
+  store = createTestStore(),
+) =>
+  renderWithStore(
+    <MemoryRouter initialEntries={[path]}>
+      <Route path={path} component={Authentication} />
+    </MemoryRouter>,
+    { store },
+  );
+
+test('logging in with valid credentials calls Firebase sign-in with the entered values', () => {
+  mockSignInWithEmailAndPassword.mockResolvedValue({
+    user: fakeFirebaseUser(),
+  });
+  const { getByPlaceholderText, getByText } = renderAuthPage('/login');
+
+  fireEvent.change(getByPlaceholderText('Email'), {
+    target: { value: 'jane@example.com' },
+  });
+  fireEvent.change(getByPlaceholderText('Password'), {
+    target: { value: 'secret1' },
+  });
+  fireEvent.click(getByText('Login'));
+
+  expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith(
+    'jane@example.com',
+    'secret1',
+  );
+});
+
+test('submitting the login form with an invalid email shows a validation error and does not call Firebase', () => {
+  const { getByPlaceholderText, getByText } = renderAuthPage('/login');
+
+  fireEvent.change(getByPlaceholderText('Email'), {
+    target: { value: 'not-an-email' },
+  });
+  fireEvent.change(getByPlaceholderText('Password'), {
+    target: { value: 'secret1' },
+  });
+  fireEvent.click(getByText('Login'));
+
+  expect(getByText('Invalid email address!')).toBeInTheDocument();
+  expect(mockSignInWithEmailAndPassword).not.toHaveBeenCalled();
+});
+
+test('registering with valid details calls Firebase sign-up and sets the display name', async () => {
+  const fakeUser = fakeFirebaseUser({ displayName: null });
+  mockCreateUserWithEmailAndPassword.mockResolvedValue({ user: fakeUser });
+  const { getByPlaceholderText, getByText } = renderAuthPage('/register');
+
+  fireEvent.change(getByPlaceholderText('Login'), {
+    target: { value: 'jane' },
+  });
+  fireEvent.change(getByPlaceholderText('Email'), {
+    target: { value: 'jane@example.com' },
+  });
+  fireEvent.change(getByPlaceholderText('Password'), {
+    target: { value: 'secret1' },
+  });
+  fireEvent.click(getByText('Register'));
+
+  expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+    'jane@example.com',
+    'secret1',
+  );
+  await wait(() =>
+    expect(fakeUser.updateProfile).toHaveBeenCalledWith({
+      displayName: 'jane',
+    }),
+  );
+});
+
+test('an existing sign-in error from the current-user context is shown on the page', () => {
+  const { getByText } = renderWithStore(
+    <MemoryRouter initialEntries={['/login']}>
+      <Route path="/login" component={Authentication} />
+    </MemoryRouter>,
+    {
+      currentUser: {
+        loading: false,
+        userData: null,
+        error: { message: 'Invalid credentials' },
+        isLoginnedUser: false,
+      },
+    },
+  );
+
+  expect(getByText('Invalid credentials')).toBeInTheDocument();
+});

--- a/src/pages/Homepage/isLoggedUser/index.test.tsx
+++ b/src/pages/Homepage/isLoggedUser/index.test.tsx
@@ -1,0 +1,136 @@
+jest.mock('store/firebase');
+
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, wait } from '@testing-library/react';
+import { renderWithStore, createTestStore } from 'testUtils';
+import IsLogginedUserPage from './index';
+import { IContact } from 'typings/interfaces';
+import {
+  mockAdd,
+  mockDelete,
+  mockUpdate,
+  mockOnSnapshot,
+  mockSignOut,
+  resetFirebaseMock,
+} from 'store/firebaseTestMocks';
+
+beforeEach(() => {
+  resetFirebaseMock();
+  mockOnSnapshot.mockImplementation(() => undefined);
+});
+
+const contact = (overrides: Partial<IContact> = {}): IContact => ({
+  activeStatus: true,
+  contactEmail: 'jane@example.com',
+  contactName: 'Jane',
+  contactPhone: '+380 (11)-111-11-11',
+  visibility: true,
+  id: '1',
+  ...overrides,
+});
+
+const currentUser = {
+  loading: false,
+  userData: { uid: 'user-1', displayName: 'Jane' },
+  error: null,
+  isLoginnedUser: true,
+};
+
+const renderHomepage = (contactsData: Array<IContact>) => {
+  const store = createTestStore({
+    contacts: { loading: false, contactsData, error: null },
+  } as any);
+  return renderWithStore(
+    <MemoryRouter>
+      <IsLogginedUserPage user={currentUser.userData} />
+    </MemoryRouter>,
+    { store, currentUser },
+  );
+};
+
+test('renders the signed-in user greeting and their visible contacts', () => {
+  const { getByText } = renderHomepage([
+    contact({ id: '1', contactName: 'Jane' }),
+    contact({ id: '2', contactName: 'John', contactEmail: 'john@example.com' }),
+  ]);
+
+  expect(getByText('Hello, Jane')).toBeInTheDocument();
+  expect(getByText('Jane')).toBeInTheDocument();
+  expect(getByText('John')).toBeInTheDocument();
+});
+
+test('submitting the add-contact form saves a new contact for the current user', () => {
+  mockAdd.mockResolvedValue(undefined);
+  const { getByPlaceholderText, getByText } = renderHomepage([]);
+
+  fireEvent.change(getByPlaceholderText('Contact Name'), {
+    target: { value: 'Jane' },
+  });
+  fireEvent.change(getByPlaceholderText('ContactEmail'), {
+    target: { value: 'jane@example.com' },
+  });
+  fireEvent.change(getByPlaceholderText('+380 (XX)-XXX-XX-XX'), {
+    target: { value: '+380 (11)-111-11-11' },
+  });
+  fireEvent.click(getByText('Submit Contact'));
+
+  expect(mockAdd).toHaveBeenCalledWith({
+    contactName: 'Jane',
+    contactEmail: 'jane@example.com',
+    contactPhone: '+380 (11)-111-11-11',
+    activeStatus: true,
+    visibility: true,
+  });
+});
+
+// Button order on the page: [Submit Contact, status-toggle, delete, Log Out].
+test('deleting a contact removes it via Firestore', () => {
+  mockDelete.mockResolvedValue(undefined);
+  const { getAllByRole } = renderHomepage([contact()]);
+
+  const [, , deleteButton] = getAllByRole('button');
+  fireEvent.click(deleteButton);
+
+  expect(mockDelete).toHaveBeenCalledTimes(1);
+});
+
+test('toggling a contact status updates it via Firestore', () => {
+  mockUpdate.mockResolvedValue(undefined);
+  const { getAllByRole } = renderHomepage([contact({ activeStatus: true })]);
+
+  const [, statusButton] = getAllByRole('button');
+  fireEvent.click(statusButton);
+
+  expect(mockUpdate).toHaveBeenCalledWith({ activeStatus: false });
+});
+
+// Visibility is CSS-driven (a hiddenContact/visibleContact class swap, see
+// contactsList/index.tsx): every contact stays mounted, so this asserts the
+// class change rather than DOM presence.
+test('filtering contacts by status marks non-matching contacts as hidden', async () => {
+  const { getByText } = renderHomepage([
+    contact({ id: '1', contactName: 'Jane', activeStatus: true }),
+    contact({ id: '2', contactName: 'John', activeStatus: false }),
+  ]);
+
+  const janeItem = () => getByText('Jane').closest('li');
+  const johnItem = () => getByText('John').closest('li');
+
+  expect(janeItem()).toHaveClass('visibleContact');
+  expect(johnItem()).toHaveClass('visibleContact');
+
+  fireEvent.click(getByText('Inactive'));
+
+  await wait(() => expect(janeItem()).toHaveClass('hiddenContact'));
+  expect(johnItem()).toHaveClass('visibleContact');
+});
+
+test('signing out logs the user out via Firebase', () => {
+  mockSignOut.mockResolvedValue(undefined);
+  const { getByText } = renderHomepage([]);
+
+  fireEvent.click(getByText('Log Out'));
+
+  expect(mockSignOut).toHaveBeenCalledTimes(1);
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/src/store/__mocks__/firebase.js
+++ b/src/store/__mocks__/firebase.js
@@ -1,0 +1,64 @@
+// Manual Jest mock for store/firebase.js (Firebase v7 compat API).
+// Activate per test file with `jest.mock('store/firebase')`, then call
+// `resetFirebaseMock()` in `beforeEach` — CRA's Jest config runs with
+// `resetMocks: true`, which wipes every jest.fn()'s return-value wiring
+// (including this chain's intermediate .collection()/.doc() links) before
+// each test, so the chain must be rebuilt every time rather than once here.
+
+export const mockSignInWithEmailAndPassword = jest.fn();
+export const mockCreateUserWithEmailAndPassword = jest.fn();
+export const mockSignOut = jest.fn();
+export const mockOnAuthStateChanged = jest.fn();
+
+export const mockOnSnapshot = jest.fn();
+export const mockAdd = jest.fn();
+export const mockDelete = jest.fn();
+export const mockUpdate = jest.fn();
+
+const contactDocRef = {
+  delete: mockDelete,
+  update: mockUpdate,
+};
+
+const contactsCollectionRef = {
+  onSnapshot: mockOnSnapshot,
+  add: mockAdd,
+  doc: jest.fn(),
+};
+
+const userDocRef = {
+  collection: jest.fn(),
+};
+
+const usersCollectionRef = {
+  doc: jest.fn(),
+};
+
+const authInstance = {
+  signInWithEmailAndPassword: mockSignInWithEmailAndPassword,
+  createUserWithEmailAndPassword: mockCreateUserWithEmailAndPassword,
+  signOut: mockSignOut,
+  onAuthStateChanged: mockOnAuthStateChanged,
+};
+
+const firestoreInstance = {
+  collection: jest.fn(),
+};
+
+const firebase = {
+  auth: jest.fn(),
+  firestore: jest.fn(),
+};
+
+export const resetFirebaseMock = () => {
+  contactsCollectionRef.doc.mockReturnValue(contactDocRef);
+  userDocRef.collection.mockReturnValue(contactsCollectionRef);
+  usersCollectionRef.doc.mockReturnValue(userDocRef);
+  firestoreInstance.collection.mockReturnValue(usersCollectionRef);
+  firebase.auth.mockReturnValue(authInstance);
+  firebase.firestore.mockReturnValue(firestoreInstance);
+};
+
+resetFirebaseMock();
+
+export default firebase;

--- a/src/store/actions/Contacts/actions.test.ts
+++ b/src/store/actions/Contacts/actions.test.ts
@@ -1,0 +1,115 @@
+jest.mock('store/firebase');
+
+import { wait } from '@testing-library/react';
+import { createTestStore } from 'testUtils';
+import {
+  FetchCurrentUserContacts,
+  SendContact,
+  deleteContactFromBook,
+  changeContactStatus,
+} from './actions';
+import {
+  mockOnSnapshot,
+  mockAdd,
+  mockDelete,
+  mockUpdate,
+  resetFirebaseMock,
+} from 'store/firebaseTestMocks';
+
+beforeEach(() => {
+  resetFirebaseMock();
+});
+
+const snapshotDoc = (id: string, data: Record<string, any>) => ({
+  id,
+  data: () => data,
+});
+
+test('FetchCurrentUserContacts subscribes to the user contact collection and stores each snapshot', () => {
+  mockOnSnapshot.mockImplementation(callback => {
+    callback({
+      docs: [
+        snapshotDoc('1', {
+          contactName: 'Jane',
+          contactEmail: 'jane@example.com',
+          contactPhone: '+380 (11)-111-11-11',
+          activeStatus: true,
+          visibility: true,
+        }),
+      ],
+    });
+  });
+  const store = createTestStore();
+
+  store.dispatch(FetchCurrentUserContacts('user-1') as any);
+
+  expect(store.getState().contacts.contactsData).toEqual([
+    {
+      id: '1',
+      contactName: 'Jane',
+      contactEmail: 'jane@example.com',
+      contactPhone: '+380 (11)-111-11-11',
+      activeStatus: true,
+      visibility: true,
+    },
+  ]);
+});
+
+test('SendContact writes a new contact document and clears the loading flag on success', async () => {
+  mockAdd.mockResolvedValue(undefined);
+  const store = createTestStore();
+
+  store.dispatch(
+    SendContact(
+      'Jane',
+      'jane@example.com',
+      '+380 (11)-111-11-11',
+      'user-1',
+    ) as any,
+  );
+
+  expect(mockAdd).toHaveBeenCalledWith({
+    contactName: 'Jane',
+    contactEmail: 'jane@example.com',
+    contactPhone: '+380 (11)-111-11-11',
+    activeStatus: true,
+    visibility: true,
+  });
+  await wait(() => expect(store.getState().contacts.loading).toBe(false));
+  expect(store.getState().contacts.error).toBeNull();
+});
+
+test('SendContact records the Firebase error on failure', async () => {
+  const error = { message: 'Failed to save' };
+  mockAdd.mockRejectedValue(error);
+  const store = createTestStore();
+
+  store.dispatch(
+    SendContact(
+      'Jane',
+      'jane@example.com',
+      '+380 (11)-111-11-11',
+      'user-1',
+    ) as any,
+  );
+
+  await wait(() => expect(store.getState().contacts.error).toEqual(error));
+});
+
+test('deleteContactFromBook deletes the contact document', async () => {
+  mockDelete.mockResolvedValue(undefined);
+  const store = createTestStore();
+
+  await store.dispatch(deleteContactFromBook('1', 'user-1') as any);
+
+  expect(mockDelete).toHaveBeenCalledTimes(1);
+});
+
+test('changeContactStatus flips the contact activeStatus', async () => {
+  mockUpdate.mockResolvedValue(undefined);
+  const store = createTestStore();
+
+  await store.dispatch(changeContactStatus('1', 'user-1', true) as any);
+
+  expect(mockUpdate).toHaveBeenCalledWith({ activeStatus: false });
+});

--- a/src/store/actions/Users/actions.test.ts
+++ b/src/store/actions/Users/actions.test.ts
@@ -1,0 +1,110 @@
+jest.mock('store/firebase');
+
+import { wait } from '@testing-library/react';
+import { createTestStore, fakeFirebaseUser } from 'testUtils';
+import { LogIn, SignUp, LogOut, IsLogIn } from './actions';
+import {
+  mockSignInWithEmailAndPassword,
+  mockCreateUserWithEmailAndPassword,
+  mockSignOut,
+  mockOnAuthStateChanged,
+  resetFirebaseMock,
+} from 'store/firebaseTestMocks';
+
+beforeEach(() => {
+  resetFirebaseMock();
+});
+
+test('LogIn signs the user in and stores the resolved user on success', async () => {
+  const fakeUser = fakeFirebaseUser();
+  mockSignInWithEmailAndPassword.mockResolvedValue({ user: fakeUser });
+  const store = createTestStore();
+
+  store.dispatch(LogIn('jane@example.com', 'secret1') as any);
+
+  expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith(
+    'jane@example.com',
+    'secret1',
+  );
+  await wait(() => expect(store.getState().user.isLoginnedUser).toBe(true));
+  expect(store.getState().user.userData).toEqual(fakeUser);
+  expect(store.getState().user.error).toBeNull();
+});
+
+test('LogIn records the Firebase error on failure without logging the user in', async () => {
+  const error = { code: 'auth/wrong-password', message: 'Invalid credentials' };
+  mockSignInWithEmailAndPassword.mockRejectedValue(error);
+  const store = createTestStore();
+
+  store.dispatch(LogIn('jane@example.com', 'wrong') as any);
+
+  await wait(() => expect(store.getState().user.error).toEqual(error));
+  expect(store.getState().user.isLoginnedUser).toBe(false);
+});
+
+test('SignUp creates the account, sets the display name, and logs the user in', async () => {
+  const fakeUser = fakeFirebaseUser({ displayName: null });
+  mockCreateUserWithEmailAndPassword.mockResolvedValue({ user: fakeUser });
+  const store = createTestStore();
+
+  store.dispatch(SignUp('jane@example.com', 'secret1', 'jane') as any);
+
+  expect(mockCreateUserWithEmailAndPassword).toHaveBeenCalledWith(
+    'jane@example.com',
+    'secret1',
+  );
+  await wait(() =>
+    expect(fakeUser.updateProfile).toHaveBeenCalledWith({
+      displayName: 'jane',
+    }),
+  );
+  await wait(() => expect(store.getState().user.isLoginnedUser).toBe(true));
+  expect(store.getState().user.userData).toEqual(fakeUser);
+});
+
+test('SignUp records the Firebase error on failure', async () => {
+  const error = { code: 'auth/email-already-in-use', message: 'Email taken' };
+  mockCreateUserWithEmailAndPassword.mockRejectedValue(error);
+  const store = createTestStore();
+
+  store.dispatch(SignUp('jane@example.com', 'secret1', 'jane') as any);
+
+  await wait(() => expect(store.getState().user.error).toEqual(error));
+});
+
+test('LogOut signs the user out and clears the session', async () => {
+  mockSignOut.mockResolvedValue(undefined);
+  const store = createTestStore({
+    user: {
+      loading: false,
+      userData: fakeFirebaseUser(),
+      error: null,
+      isLoginnedUser: true,
+    },
+  } as any);
+
+  store.dispatch(LogOut() as any);
+
+  await wait(() => expect(store.getState().user.isLoginnedUser).toBe(false));
+  expect(store.getState().user.userData).toBeNull();
+});
+
+test('IsLogIn restores a persisted session when Firebase reports a signed-in user', async () => {
+  const fakeUser = fakeFirebaseUser();
+  mockOnAuthStateChanged.mockImplementation(callback => callback(fakeUser));
+  const store = createTestStore();
+
+  store.dispatch(IsLogIn() as any);
+
+  await wait(() => expect(store.getState().user.isLoginnedUser).toBe(true));
+  expect(store.getState().user.userData).toEqual(fakeUser);
+});
+
+test('IsLogIn reports no session when Firebase has no signed-in user', async () => {
+  mockOnAuthStateChanged.mockImplementation(callback => callback(null));
+  const store = createTestStore();
+
+  store.dispatch(IsLogIn() as any);
+
+  await wait(() => expect(store.getState().user.isLoginnedUser).toBe(false));
+});

--- a/src/store/firebaseTestMocks.ts
+++ b/src/store/firebaseTestMocks.ts
@@ -1,0 +1,25 @@
+// Typed access to store/__mocks__/firebase.js's mock helpers.
+//
+// TypeScript resolves `import ... from 'store/firebase'` against the real
+// module (only a default export), so it can't see the extra named exports
+// the manual mock adds. Jest, on the other hand, only swaps in the manual
+// mock for a module path once `jest.mock('store/firebase')` has run in the
+// current test file — importing straight from '__mocks__/firebase' would
+// load a second, disconnected module instance instead. Casting the
+// namespace import to the mock's own type gets both right: correct runtime
+// wiring, no `as any` at every call site.
+import * as firebaseNs from 'store/firebase';
+
+const mocks = (firebaseNs as unknown) as typeof import('./__mocks__/firebase');
+
+export const {
+  mockSignInWithEmailAndPassword,
+  mockCreateUserWithEmailAndPassword,
+  mockSignOut,
+  mockOnAuthStateChanged,
+  mockOnSnapshot,
+  mockAdd,
+  mockDelete,
+  mockUpdate,
+  resetFirebaseMock,
+} = mocks;

--- a/src/store/reducers/contacts.test.ts
+++ b/src/store/reducers/contacts.test.ts
@@ -1,0 +1,83 @@
+import contacts from './contacts';
+import {
+  GET_CURRENT_USER_CONTACTS,
+  SEND_CONTACT_SUCCESS,
+  SEND_CONTACT_ERROR,
+  FILTERED_CONTACT_BY_EMAIL,
+  FILTERED_CONTACT_BY_STATUS,
+} from 'store/constants';
+import { IContact } from 'typings/interfaces';
+
+const INITIAL_STATE = {
+  loading: false,
+  contactsData: [],
+  error: null,
+};
+
+const contact = (overrides: Partial<IContact> = {}): IContact => ({
+  activeStatus: true,
+  contactEmail: 'a@b.com',
+  contactName: 'A',
+  contactPhone: '+380 (11)-111-11-11',
+  visibility: true,
+  id: '1',
+  ...overrides,
+});
+
+test('returns the initial state by default', () => {
+  expect(contacts(undefined, { type: '@@INIT' } as any)).toEqual(INITIAL_STATE);
+});
+
+test('GET_CURRENT_USER_CONTACTS replaces the contact list from a snapshot', () => {
+  const contactsData = [contact()];
+  const state = contacts(INITIAL_STATE, {
+    type: GET_CURRENT_USER_CONTACTS,
+    contactsData,
+  } as any);
+  expect(state.contactsData).toEqual(contactsData);
+});
+
+test('SEND_CONTACT_SUCCESS clears loading and error', () => {
+  const state = contacts(
+    { ...INITIAL_STATE, loading: true, error: { message: 'x' } },
+    { type: SEND_CONTACT_SUCCESS, loading: false, error: null } as any,
+  );
+  expect(state.loading).toBe(false);
+  expect(state.error).toBeNull();
+});
+
+test('SEND_CONTACT_ERROR records the error', () => {
+  const error = { message: 'Failed to save' };
+  const state = contacts(INITIAL_STATE, {
+    type: SEND_CONTACT_ERROR,
+    error,
+  } as any);
+  expect(state.error).toEqual(error);
+});
+
+test('FILTERED_CONTACT_BY_EMAIL narrows visibility to the selected contact', () => {
+  const contactsData = [
+    contact({ id: '1', contactEmail: 'a@b.com', visibility: true }),
+    contact({ id: '2', contactEmail: 'c@d.com', visibility: false }),
+  ];
+  const state = contacts(
+    {
+      ...INITIAL_STATE,
+      contactsData: [contact({ id: '1' }), contact({ id: '2' })],
+    },
+    { type: FILTERED_CONTACT_BY_EMAIL, contactsData } as any,
+  );
+  expect(state.contactsData).toEqual(contactsData);
+});
+
+test('FILTERED_CONTACT_BY_STATUS replaces the list with the filtered visibility set', () => {
+  const contactsData = [
+    contact({ id: '1', activeStatus: true, visibility: true }),
+    contact({ id: '2', activeStatus: false, visibility: false }),
+  ];
+  const state = contacts(INITIAL_STATE, {
+    type: FILTERED_CONTACT_BY_STATUS,
+    contactsData,
+  } as any);
+  expect(state.contactsData).toEqual(contactsData);
+});

--- a/src/store/reducers/user.test.ts
+++ b/src/store/reducers/user.test.ts
@@ -1,0 +1,104 @@
+import user from './user';
+import {
+  LOG_IN_STARTED,
+  LOG_IN_SUCCESS,
+  LOG_IN_ERROR,
+  SIGN_UP_SUCCESS,
+  SIGN_OUT_SUCCESS,
+  IS_LOG_IN_SUCCESS,
+  IS_LOG_IN_ERROR,
+} from 'store/constants';
+
+const INITIAL_STATE = {
+  loading: false,
+  userData: null,
+  error: null,
+  isLoginnedUser: false,
+};
+
+test('returns the initial state by default', () => {
+  expect(user(undefined, { type: '@@INIT' } as any)).toEqual(INITIAL_STATE);
+});
+
+test('LOG_IN_STARTED flips loading on', () => {
+  const state = user(INITIAL_STATE, {
+    type: LOG_IN_STARTED,
+    loading: true,
+  } as any);
+  expect(state.loading).toBe(true);
+});
+
+test('LOG_IN_SUCCESS stores the user and clears loading/error', () => {
+  const fakeUser = { uid: '1', displayName: 'Jane' };
+  const state = user(INITIAL_STATE, {
+    type: LOG_IN_SUCCESS,
+    userData: fakeUser,
+    loading: false,
+    error: null,
+    isLoginnedUser: true,
+  } as any);
+  expect(state).toEqual({
+    loading: false,
+    userData: fakeUser,
+    error: null,
+    isLoginnedUser: true,
+  });
+});
+
+test('LOG_IN_ERROR records the error without touching the rest of the state', () => {
+  const error = { message: 'Invalid credentials' };
+  const state = user(INITIAL_STATE, { type: LOG_IN_ERROR, error } as any);
+  expect(state.error).toEqual(error);
+  expect(state.userData).toBeNull();
+});
+
+test('SIGN_UP_SUCCESS logs the newly registered user in', () => {
+  const fakeUser = { uid: '2', displayName: 'John' };
+  const state = user(INITIAL_STATE, {
+    type: SIGN_UP_SUCCESS,
+    userData: fakeUser,
+    loading: false,
+    error: null,
+    isLoginnedUser: true,
+  } as any);
+  expect(state.userData).toEqual(fakeUser);
+  expect(state.isLoginnedUser).toBe(true);
+});
+
+test('SIGN_OUT_SUCCESS clears the user', () => {
+  const loggedIn = {
+    loading: false,
+    userData: { uid: '1' },
+    error: null,
+    isLoginnedUser: true,
+  };
+  const state = user(loggedIn, {
+    type: SIGN_OUT_SUCCESS,
+    userData: null,
+    loading: false,
+    error: null,
+    isLoginnedUser: false,
+  } as any);
+  expect(state).toEqual(INITIAL_STATE);
+});
+
+test('IS_LOG_IN_SUCCESS restores a persisted session', () => {
+  const fakeUser = { uid: '3' };
+  const state = user(INITIAL_STATE, {
+    type: IS_LOG_IN_SUCCESS,
+    userData: fakeUser,
+    loading: false,
+    error: null,
+    isLoginnedUser: true,
+  } as any);
+  expect(state.userData).toEqual(fakeUser);
+  expect(state.isLoginnedUser).toBe(true);
+});
+
+test('IS_LOG_IN_ERROR marks no session as found', () => {
+  const state = user(INITIAL_STATE, {
+    type: IS_LOG_IN_ERROR,
+    isLoginnedUser: false,
+  } as any);
+  expect(state.isLoginnedUser).toBe(false);
+});

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,0 +1,52 @@
+// Shared render/store helpers for smoke tests (not picked up by Jest's
+// testMatch since it's neither *.test.* nor inside __tests__/).
+import React from 'react';
+import { createStore, applyMiddleware, combineReducers, Store } from 'redux';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { render, RenderResult } from '@testing-library/react';
+import { reducer as formReducer } from 'redux-form';
+import contacts from 'store/reducers/contacts';
+import user from 'store/reducers/user';
+import { RootState } from 'store/reducers';
+import { CurrentUserContext } from 'context';
+import { IUser } from 'typings/interfaces';
+
+const rootReducer = combineReducers({ user, contacts, form: formReducer });
+
+export const defaultCurrentUser: IUser = {
+  loading: false,
+  userData: null,
+  error: null,
+  isLoginnedUser: false,
+};
+
+export const createTestStore = (preloadedState?: Partial<RootState>): Store =>
+  createStore(rootReducer, preloadedState as RootState, applyMiddleware(thunk));
+
+export const renderWithStore = (
+  ui: React.ReactElement,
+  {
+    store = createTestStore(),
+    currentUser = defaultCurrentUser,
+  }: { store?: Store; currentUser?: IUser } = {},
+): { store: Store } & RenderResult => ({
+  store,
+  ...render(
+    <Provider store={store}>
+      <CurrentUserContext.Provider value={currentUser}>
+        {ui}
+      </CurrentUserContext.Provider>
+    </Provider>,
+  ),
+});
+
+export const fakeFirebaseUser = (
+  overrides: Record<string, any> = {},
+): Record<string, any> => ({
+  uid: 'user-1',
+  email: 'jane@example.com',
+  displayName: 'Jane',
+  updateProfile: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});

--- a/src/utils/index.test.tsx
+++ b/src/utils/index.test.tsx
@@ -1,0 +1,38 @@
+import { validate } from './index';
+
+test('flags all required fields as missing when empty', () => {
+  const errors = validate({});
+  expect(errors.contactName).toBe('This field is required!');
+  expect(errors.contactEmail).toBe('This field is required!');
+  expect(errors.contactPhone).toBe('This field is required!');
+  expect(errors.userLogin).toBe('This field is required!');
+  expect(errors.userEmail).toBe('This field is required!');
+  expect(errors.userPassword).toBe('This field is required!');
+});
+
+test('rejects an invalid email address', () => {
+  const errors = validate({ userEmail: 'not-an-email' });
+  expect(errors.userEmail).toBe('Invalid email address!');
+});
+
+test('rejects a password shorter than 6 characters', () => {
+  const errors = validate({ userPassword: '123' });
+  expect(errors.userPassword).toBe('Must be 6 characters or more');
+});
+
+test('rejects a contact phone that does not match the expected format', () => {
+  const errors = validate({ contactPhone: '123-456' });
+  expect(errors.contactPhone).toBe('Invalid phone number!');
+});
+
+test('accepts a fully valid set of values with no errors', () => {
+  const errors = validate({
+    contactName: 'Jane',
+    contactEmail: 'jane@example.com',
+    contactPhone: '+380 (11)-111-11-11',
+    userLogin: 'jane',
+    userEmail: 'jane@example.com',
+    userPassword: 'secret1',
+  });
+  expect(errors).toEqual({});
+});


### PR DESCRIPTION
## Summary
- Adds smoke tests for the flows the Next.js/Firebase-modular/RHF migration must not break: register, login, add/delete a contact, toggle status, and filter by email/status — with Firebase (auth + Firestore) mocked so they run standalone.
- Fills two gaps that were silently blocking the already-listed testing-library dependencies from working at all: no `src/setupTests.ts` (jest-dom matchers were never registered) and no `@types/jest` devDependency.
- Adds `MODERNIZATION_PLAN.md` to version control (previously untracked) and checks off Phase 0 in its progress log.

## Test plan
- [x] `react-scripts test` — 7 suites / 41 tests pass
- [x] `tsc --noEmit` — clean
- [x] `eslint` — 0 errors (1 unavoidable warning on the plain-JS Firebase mock file, documented inline)

## Notes for reviewers
- `node-sass` cannot build in a Node 24 environment without `python` on `PATH` — pre-existing and unrelated to this PR; doesn't affect Jest since CRA's test config stubs Sass/CSS imports entirely. This is exactly what Phase 1+ (Tailwind swap) resolves.
- This PR targets `feature/modernize-2026`, not `master`, per the phased workflow in `MODERNIZATION_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)